### PR TITLE
Twitter bot: Fix duplicate tweet_id being stored in tid_store

### DIFF
--- a/nawab_bot.py
+++ b/nawab_bot.py
@@ -66,11 +66,10 @@ def nawab_get_id(dirpath):
 
 def nawab_check_tweet(tweet_id, dirpath):
     with open(dirpath + "tid_store.txt", "r") as fp:
-        for line in fp:
-            if line == tweet_id:
-                return True
-            else:
-                return False
+         if any(line.strip() == tweet_id for line in fp):
+             return True
+         else:
+             return False
 
 
 def nawab_curate_list(api, data, dirpath):


### PR DESCRIPTION
- Used any method to iterate through the tweet id in tid_store.txt to check if  tweet_id passed as argument is already existent in tid_store.txt or not.