### PR TITLE
Nawab_Logger: Resolved logger giving multiple entries

### DIFF
--- a/nawab_logger.py
+++ b/nawab_logger.py
@@ -16,9 +16,13 @@ class Nawab_Logging(object):
         fileHandler.setFormatter(formatter)
         streamHandler = logging.StreamHandler()
         streamHandler.setFormatter(formatter)
+        ## Clear up any existing in handler
         log_setup.setLevel(level)
+        if (log_setup.hasHandlers()):
+            log_setup.handlers.clear()
         log_setup.addHandler(fileHandler)
         log_setup.addHandler(streamHandler)
+        log_setup.propagate = False
 
     def logger(self, msg, level, logfile):
 


### PR DESCRIPTION
- Added a hasHandler() method to check if the logger has multiple handlers in the object instance.
The link to this issue can be found [1](https://stackoverflow.com/questions/19561058/duplicate-output-in-simple-python-logging-configuration/19561320#19561320) and [2](https://stackoverflow.com/questions/7173033/duplicate-log-output-when-using-python-logging-module)