### PR TITLE
Recent tweets will only be scraped

### DIFF
--- a/nawab.py
+++ b/nawab.py
@@ -32,7 +32,7 @@ class Nawab(object):
 
     def tg_bot_run(self, auto_retweet=None):
         tw_bot, api = self.retrieve_twitter_auth()
-        bot = tg_bot.Telegram_Bot(api, self.dirpath, self.level, auto_retweet)
+        bot = tg_bot.Telegram_Bot(api, self.dirpath, self.data, self.level, auto_retweet)
         updater = bot.nawab_tg_authenticate()
 
         dp = updater.dispatcher

--- a/tg_bot.py
+++ b/tg_bot.py
@@ -9,6 +9,7 @@ import nawab_logger
 import pandas as pd
 import inspect
 
+from datetime import timedelta, datetime, date
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import Updater, CommandHandler, CallbackQueryHandler, ConversationHandler
 
@@ -45,8 +46,23 @@ class Telegram_Bot(object):
         job = context.job
         global KILL_SIGNAL
         tid = pd.read_csv(self.dirpath + 'tid_store.csv')
-        for index, tid_store in tid.iterrows():
-
+        tid["Date_time"]= pd.to_datetime(tid["Date_time"])
+        previous_date = tid['Date_time'].iloc[-1]
+        
+        #to find the previous date in the tid
+        for index, tid_store in tid[::-1].iterrows():
+            scrape_datetime = tid_store['Date_time']
+            scrape_date = date(scrape_datetime.year, scrape_datetime.month, scrape_datetime.day)
+            if scrape_date!=previous_date:
+                previous_date = scrape_date
+                break
+            else:
+                continue
+        
+        for index, tid_store in tid[::-1].iterrows():
+            scrape_date = tid_store['Date_time']
+            if scrape_date<=previous_date:
+                break
             try:
                 u = self.twitter_api.get_status(id=tid_store['Id'])
                 username = u.author.screen_name

--- a/twitter_bot.py
+++ b/twitter_bot.py
@@ -87,6 +87,20 @@ class Twitter_Bot(object):
         tid_store = pd.read_csv('tid_store.csv')
         return tid_store['Id']  
 
+    def nawab_find_prev_date(self):
+        """to find the previous date in the tid"""
+        tid = pd.read_csv(self.dirpath + 'tid_store.csv')
+        tid["Date_time"]= pd.to_datetime(tid["Date_time"])
+        previous_date = tid['Date_time'].iloc[-1]
+        #find the previous date by iterating tid_store bottom-up 
+        for index, tid_store in tid[::-1].iterrows():
+            scrape_datetime = tid_store['Date_time']
+            scrape_date = date(scrape_datetime.year, scrape_datetime.month, scrape_datetime.day)
+            if scrape_date!=previous_date:
+                previous_date = scrape_date
+                break;
+        return previous_date
+
     def nawab_check_relevant(self, query, text):
         """Check for count of keywords in text"""
         cnt = 0

--- a/twitter_bot.py
+++ b/twitter_bot.py
@@ -6,7 +6,7 @@ import tweepy
 import mmap
 import time
 import random
-from datetime import date
+from datetime import date, datetime
 import csv
 import os
 import logging
@@ -50,13 +50,13 @@ class Twitter_Bot(object):
     def nawab_store_id(self, tweet_id, isrelevant):
         ### Store a tweet id in a file
         if isrelevant:
-            dicts = {'Date_time': [time.strftime("%m/%d/%Y %I:%M:%S %p")],
+            dicts = {'Date_time': [datetime.now()],
                      'Id': [str(tweet_id)]}
             data = pd.DataFrame(dicts)
             data.to_csv(self.dirpath + 'tid_store.csv',
                         mode='a', header=False, index=False)
         else:
-            dicts = {'Date_time': [time.strftime("%m/%d/%Y %I:%M:%S %p")],
+            dicts = {'Date_time': [datetime.now()],
                      'Id': [str(tweet_id)]}
             data = pd.DataFrame(dicts)
             data.to_csv(self.dirpath + 'backup_tid_store.csv',


### PR DESCRIPTION
This commit does
- Recent tweets are only being scraped; logic being tweets scraped before the day the /start command is passed wont be sent to the telegram user
- Converts the format of date being logged in tid_store.csv